### PR TITLE
llvm -> clang

### DIFF
--- a/src/cpuid/config.hpp
+++ b/src/cpuid/config.hpp
@@ -48,13 +48,13 @@
     #endif
 #elif defined(CPUID_MAC)
     #if defined(__llvm__)
-        #define CPUID_MAC_LLVM
+        #define CPUID_MAC_CLANG
     #elif defined(__GNUC__)
         #define CPUID_MAC_GCC
     #endif
 #elif defined(CPUID_IOS)
     #if defined(__llvm__)
-        #define CPUID_IOS_LLVM
+        #define CPUID_IOS_CLANG
     #endif
 #endif
 
@@ -102,20 +102,20 @@
         #define CPUID_WIN32_MSVC_ARM
         #define CPUID_PLATFORM "win32_msvc_arm"
     #endif
-#elif defined(CPUID_MAC_LLVM)
+#elif defined(CPUID_MAC_CLANG)
     #if defined(__i386__) || defined(__x86_64__)
-        #define CPUID_MAC_LLVM_X86
-        #define CPUID_PLATFORM "mac_llvm_x86"
+        #define CPUID_MAC_CLANG_X86
+        #define CPUID_PLATFORM "mac_clang_x86"
     #endif
 #elif defined(CPUID_MAC_GCC)
     #if defined(__i386__) || defined(__x86_64__)
         #define CPUID_MAC_GCC_X86
         #define CPUID_PLATFORM "mac_gcc_x86"
     #endif
-#elif defined(CPUID_IOS_LLVM)
+#elif defined(CPUID_IOS_CLANG)
     #if defined(__arm__)
-        #define CPUID_IOS_LLVM_ARM
-        #define CPUID_PLATFORM "ios_llvm_arm"
+        #define CPUID_IOS_CLANG_ARM
+        #define CPUID_PLATFORM "ios_clang_arm"
     #endif
 #else
     #define CPUID_UNKNOWN

--- a/src/cpuid/cpuinfo.cpp
+++ b/src/cpuid/cpuinfo.cpp
@@ -23,12 +23,12 @@
     #include "init_linux_gcc_arm.hpp"
 #elif defined(CPUID_WIN32_MSVC_X86)
     #include "init_win32_msvc_x86.hpp"
-#elif defined(CPUID_MAC_LLVM_X86)
+#elif defined(CPUID_MAC_CLANG_X86)
     #include "init_linux_gcc_x86.hpp"
 #elif defined(CPUID_MAC_GCC_X86)
     #include "init_linux_gcc_x86.hpp"
-#elif defined(CPUID_IOS_LLVM_ARM)
-    #include "init_ios_llvm_arm.hpp"
+#elif defined(CPUID_IOS_CLANG_ARM)
+    #include "init_ios_clang_arm.hpp"
 #else
     #include "init_unknown.hpp"
 #endif

--- a/src/cpuid/init_ios_clang_arm.hpp
+++ b/src/cpuid/init_ios_clang_arm.hpp
@@ -13,7 +13,7 @@ namespace cpuid
     /// @todo docs
     void init_cpuinfo(cpuinfo::impl& info)
     {
-        // The __ARM_NEON__ macro will be defined by the Apple LLVM compiler
+        // The __ARM_NEON__ macro will be defined by the Apple Clang compiler
         // when targeting ARMv7 processors that have NEON.
         // The compiler guarantees this capability, so there is no benefit
         // in doing a runtime check. More info in this SO answer:


### PR DESCRIPTION
renamed llvm to clang for consistency. :baby_chick:
