### PR TITLE
fix build with pic flag on x86

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -6,7 +6,7 @@ every change, see the Git log.
 
 Latest
 ------
-* tbd
+* Bug: Fixed issue with the -fPIC compile flag and x86 architecture.
 
 3.0.0
 -----

--- a/src/cpuid/init_gcc_x86.hpp
+++ b/src/cpuid/init_gcc_x86.hpp
@@ -21,6 +21,7 @@ namespace cpuid
         uint32_t ebx = 0;
         uint32_t ecx = 0;
         uint32_t edx = 0;
+
         __get_cpuid(1, &eax, &ebx, &ecx, &edx);
 
         // Get flags


### PR DESCRIPTION
I've fixed a minor issue when specifying the -fPIC flag (used in fifi-swig). It seems that one of the registers are being used by pic.

http://gcc.1065356.n5.nabble.com/attachment/900384/0/r.diff.txt
