### PR TITLE
Add support for aes flag on x86

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,8 @@ Member functions (public)
 +------------------------------------------------------------+----------------------------------------------------------------+
 |                                                            | `~cpuinfo <id13_>`_ ()                                         |
 +------------------------------------------------------------+----------------------------------------------------------------+
+| `bool <https://en.cppreference.com/w/cpp/language/types>`_ | `has_aes <cpuid-cpuinfo-has-aes-const_>`_ () const             |
++------------------------------------------------------------+----------------------------------------------------------------+
 | `bool <https://en.cppreference.com/w/cpp/language/types>`_ | `has_avx <cpuid-cpuinfo-has-avx-const_>`_ () const             |
 +------------------------------------------------------------+----------------------------------------------------------------+
 | `bool <https://en.cppreference.com/w/cpp/language/types>`_ | `has_avx2 <cpuid-cpuinfo-has-avx2-const_>`_ () const           |
@@ -174,6 +176,16 @@ Member Function Description
 ..
 
    Destructor.
+
+======================================================================
+
+.. _cpuid-cpuinfo-has-aes-const:
+
+`bool <https://en.cppreference.com/w/cpp/language/types>`_ **has_aes** ()
+
+..
+
+   Return true if the CPU supports AES.
 
 ======================================================================
 

--- a/examples/print_cpuinfo/main.cpp
+++ b/examples/print_cpuinfo/main.cpp
@@ -47,6 +47,9 @@ int main()
     std::cout << "CPU has F16C?: " << (m_cpuid.has_f16c() ? "Yes" : "No")
               << std::endl;
 
+    std::cout << "CPU has AES?: " << (m_cpuid.has_aes() ? "Yes" : "No")
+              << std::endl;
+
     std::cout << "CPU has ARM NEON?: " << (m_cpuid.has_neon() ? "Yes" : "No")
               << std::endl;
 

--- a/src/cpuid/cpuinfo.cpp
+++ b/src/cpuid/cpuinfo.cpp
@@ -98,6 +98,11 @@ bool cpuinfo::has_f16c() const
     return m_impl->m_has_f16c;
 }
 
+bool cpuinfo::has_aes() const
+{
+    return m_impl->m_has_aes;
+}
+
 // ARM member functions
 bool cpuinfo::has_neon() const
 {

--- a/src/cpuid/cpuinfo.hpp
+++ b/src/cpuid/cpuinfo.hpp
@@ -60,6 +60,9 @@ public:
     /// Return true if the CPU supports F16C
     bool has_f16c() const;
 
+    /// Return true if the CPU supports AES
+    bool has_aes() const;
+
     /// Return true if the CPU supports NEON
     bool has_neon() const;
 

--- a/src/cpuid/detail/cpuinfo_impl.hpp
+++ b/src/cpuid/detail/cpuinfo_impl.hpp
@@ -18,7 +18,8 @@ struct cpuinfo::impl
         m_has_fpu(false), m_has_mmx(false), m_has_sse(false), m_has_sse2(false),
         m_has_sse3(false), m_has_ssse3(false), m_has_sse4_1(false),
         m_has_sse4_2(false), m_has_pclmulqdq(false), m_has_avx(false),
-        m_has_avx2(false), m_has_f16c(false), m_has_neon(false)
+        m_has_avx2(false), m_has_f16c(false), m_has_aes(false),
+        m_has_neon(false)
     {
     }
 
@@ -34,6 +35,7 @@ struct cpuinfo::impl
     bool m_has_avx;
     bool m_has_avx2;
     bool m_has_f16c;
+    bool m_has_aes;
     bool m_has_neon;
 };
 }

--- a/src/cpuid/detail/extract_x86_flags.hpp
+++ b/src/cpuid/detail/extract_x86_flags.hpp
@@ -27,6 +27,7 @@ void extract_x86_flags(cpuinfo::impl& info, uint32_t ecx, uint32_t edx)
     info.m_has_sse4_2 = (ecx & (1 << 20)) != 0;
     info.m_has_pclmulqdq = (ecx & (1 << 1)) != 0;
     info.m_has_avx = (ecx & (1 << 28)) != 0;
+    info.m_has_aes = (ecx & (1 << 25)) != 0;
     info.m_has_f16c = (ecx & (1 << 29)) != 0;
 }
 

--- a/test/commandline_arguments.cpp
+++ b/test/commandline_arguments.cpp
@@ -25,6 +25,7 @@ commandline_arguments::commandline_arguments()
         "has_avx", po::value<bool>()->default_value(false))(
         "has_avx2", po::value<bool>()->default_value(false))(
         "has_f16c", po::value<bool>()->default_value(false))(
+        "has_aes", po::value<bool>()->default_value(false))(
         "has_neon", po::value<bool>()->default_value(false));
 }
 

--- a/test/src/test_cpuinfo.cpp
+++ b/test/src/test_cpuinfo.cpp
@@ -29,5 +29,6 @@ TEST(cpuinfo_tests, check_instruction_sets)
     EXPECT_EQ(variable_map["has_avx"].as<bool>(), m_cpuinfo.has_avx());
     EXPECT_EQ(variable_map["has_avx2"].as<bool>(), m_cpuinfo.has_avx2());
     EXPECT_EQ(variable_map["has_f16c"].as<bool>(), m_cpuinfo.has_f16c());
+    EXPECT_EQ(variable_map["has_aes"].as<bool>(), m_cpuinfo.has_aes());
     EXPECT_EQ(variable_map["has_neon"].as<bool>(), m_cpuinfo.has_neon());
 }


### PR DESCRIPTION
Hello.
Based on information from [Microsoft documentation] (https://learn.microsoft.com/en-us/cpp/intrinsics/cpuid-cpuidex?redirectedfrom=MSDN&view=msvc-170). Unfortunately, I cannot implement support for the arm architecture due to the lack of it.